### PR TITLE
在文件已存在的时候询问是否覆盖

### DIFF
--- a/QuickCut.py
+++ b/QuickCut.py
@@ -602,6 +602,13 @@ class FFmpegMainTab(QWidget):
     # 点击运行按钮
     def runFinalCommandButtonClicked(self):
         finalCommand = self.总命令编辑框.toPlainText()
+        outputPath = self.输出路径框.text()
+        if os.path.exists(outputPath):
+            overwrite = QMessageBox.warning(
+                self, '确认', '输出路径对应的文件已存在，确认覆盖？',
+                QMessageBox.Yes | QMessageBox.Cancel, QMessageBox.Cancel)
+            if overwrite != QMessageBox.Yes:
+                return
         if finalCommand != '':
             execute(finalCommand)
 


### PR DESCRIPTION
程序每次调用FFmpeg时都会自动加上`-y`选项覆盖已经存在的文件，但用户很有可能并没有意识到这个选项的意义，即使意识到也可能因为误操作不小心覆盖已存在的文件，因此需要先向用户确认是否覆盖以避免不必要的损失。