### PR TITLE
修复未定义和重复的属性

### DIFF
--- a/QuickCut.py
+++ b/QuickCut.py
@@ -3366,17 +3366,6 @@ class FFmpegAutoSrtTab(QWidget):
         outputFilePath = self.voiceInputMethodSubtitleOutputEdit.text()
         shortcutOfInputMethod = self.voiceInputMethodSubtitleVoiceInputShortcutComboBox.currentText()
         userDefinedEndtime = strTimeToSecondsTime(self.voiceInputMethodSubtitle截取时间end输入框.text())  # 用户输入的终止时间
-        try:
-            inputFileLength = getMediaTimeLength(self.voiceInputMethodSubtitleInputEdit.text())  # 结束时间即为媒体时长
-        except RuntimeError:
-            # Catch the exception raised by pymediainfo.MediaInfo.parse
-            QMessageBox.information(self, '错误', '输入文件有误')
-            return
-
-        if userDefinedEndtime > 0:
-            endTime = userDefinedEndtime  # 结束时间为用户定义的时间
-        else:
-            endTime = inputFileLength  # 结束时间即为媒体时长
         startTime = strTimeToSecondsTime(self.voiceInputMethodSubtitle截取时间start输入框.text())  # 确定起始时间
 
         thread = VoiceInputMethodAutoSrtThread()  # 控制输入法进程
@@ -3384,9 +3373,9 @@ class FFmpegAutoSrtTab(QWidget):
         ffmpegWavGenThread = FFmpegWavGenThread()  # 得到 wav 文件进程
         ffmpegWavGenThread.mediaFile = inputFilePath
         ffmpegWavGenThread.startTime = startTime
-        ffmpegWavGenThread.endTime = endTime
 
         window = VoiceInputMethodTranscribeSubtitleWindow(main)  # 新窗口
+        output = window.hintConsoleBox
 
         window.thread = thread
         window.transEngine = transEngine
@@ -3395,6 +3384,20 @@ class FFmpegAutoSrtTab(QWidget):
         window.inputFiePath = inputFilePath  # 输入路径
         window.outputFilePath = outputFilePath  # 输出路径
         window.shortcutOfInputMethod = shortcutOfInputMethod  # 输入法的快捷键
+
+        try:
+            inputFileLength = getMediaTimeLength(self.voiceInputMethodSubtitleInputEdit.text())  # 结束时间即为媒体时长
+        except (RuntimeError, FileNotFoundError):
+            # Catch the exception raised by pymediainfo.MediaInfo.parse
+            output.print('输入文件有误')
+            return
+
+        if userDefinedEndtime > 0:
+            endTime = userDefinedEndtime  # 结束时间为用户定义的时间
+        else:
+            endTime = inputFileLength  # 结束时间即为媒体时长
+
+        ffmpegWavGenThread.endTime = endTime
 
         if userDefinedEndtime > 0:
             window.endTime = endTime  # 结束时间为用户定义的时间

--- a/QuickCut.py
+++ b/QuickCut.py
@@ -1446,7 +1446,7 @@ self.finalCommand = r'''ffmpeg -y -hide_banner -i "%s" -passlogfile "%s"  -c:v l
                 except:
                     QMessageBox.warning(self, self.tr('添加预设'), self.tr('新预设添加失败，你可以把失败过程重新操作记录一遍，然后发给作者'))
             else:
-                answer = QMessageBox.question(self, self.tr('覆盖预设'), tr('''已经存在名字相同的预设，你可以选择换一个预设名字或者覆盖旧的预设。是否要覆盖？'''))
+                answer = QMessageBox.question(self, self.tr('覆盖预设'), self.tr('''已经存在名字相同的预设，你可以选择换一个预设名字或者覆盖旧的预设。是否要覆盖？'''))
                 if answer == QMessageBox.Yes:  # 如果同意覆盖
                     try:
                         conn.cursor().execute(
@@ -3365,17 +3365,18 @@ class FFmpegAutoSrtTab(QWidget):
         inputFilePath = self.voiceInputMethodSubtitleInputEdit.text()
         outputFilePath = self.voiceInputMethodSubtitleOutputEdit.text()
         shortcutOfInputMethod = self.voiceInputMethodSubtitleVoiceInputShortcutComboBox.currentText()
-        userDefinedStarttime = strTimeToSecondsTime(self.voiceInputMethodSubtitle截取时间start输入框.text())  # 用户输入的起始时间
         userDefinedEndtime = strTimeToSecondsTime(self.voiceInputMethodSubtitle截取时间end输入框.text())  # 用户输入的终止时间
-        inputFileLength = getMediaTimeLength(self.voiceInputMethodSubtitleInputEdit.text())  # 结束时间即为媒体时长
+        try:
+            inputFileLength = getMediaTimeLength(self.voiceInputMethodSubtitleInputEdit.text())  # 结束时间即为媒体时长
+        except RuntimeError:
+            # Catch the exception raised by pymediainfo.MediaInfo.parse
+            QMessageBox.information(self, '错误', '输入文件有误')
+            return
 
         if userDefinedEndtime > 0:
             endTime = userDefinedEndtime  # 结束时间为用户定义的时间
         else:
-            try:
-                endTime = getMediaTimeLength(self.voiceInputMethodSubtitleInputEdit.text())  # 结束时间即为媒体时长
-            except:
-                output.print(self.tr('输入文件有误'))
+            endTime = inputFileLength  # 结束时间即为媒体时长
         startTime = strTimeToSecondsTime(self.voiceInputMethodSubtitle截取时间start输入框.text())  # 确定起始时间
 
         thread = VoiceInputMethodAutoSrtThread()  # 控制输入法进程
@@ -3398,10 +3399,7 @@ class FFmpegAutoSrtTab(QWidget):
         if userDefinedEndtime > 0:
             window.endTime = endTime  # 结束时间为用户定义的时间
         else:
-            try:
-                window.endTime = inputFileLength  # 结束时间即为媒体时长
-            except:
-                output.print(self.tr('输入文件有误'))
+            window.endTime = inputFileLength  # 结束时间即为媒体时长
         window.startTime = startTime  # 确定起始时间
         window.initParams()
 


### PR DESCRIPTION
- 原1449行`tr`应为`self.tr`
- 原3368行`userDefinedStarttime`从未使用，且与`startTime`重复
- 原3378、3404行`output`未定义，推测是在读取文件失败时弹出提示，故改为对话框形式
- 原3376行`endTime`的赋值与`inputFileLength`重复，直接把后者赋给前者即可
- 将`except:`改为了`except RuntimeError:`并添加注释，以增加可读性

代码中还有一些其他的重复变量，这里只是发现两个未定义的变量时顺带修复了几个。

如果作者用的是PyCharm的话，推荐至少打开Inspections中的Error，这样可以有效避免出现未定义的变量。