### PR TITLE
新增 Linux 下 PyInstaller 的构建脚本

### DIFF
--- a/build_linux_pyinstaller
+++ b/build_linux_pyinstaller
@@ -1,0 +1,77 @@
+#!/usr/bin/env sh
+set -euo pipefail
+SEP=`python3 -c 'import os; print(os.pathsep)'`
+ARCH=`arch`
+VERSION=`python3 -c 'from QuickCut import version; print(version)'`
+
+# Check if setuptools is up-to-date
+outdated=`pip list --outdated`
+if [[ $outdated  == *'setuptools'* ]]; then
+    echo 'setuptools not up-to-date'
+    echo 'Please update it with "pip install setuptools --upgrade"'
+    exit 1
+fi
+
+# Check if pyinstaller is installed
+pip_list=`pip list | grep 'PyInstaller'` || pip_list=''
+if [[ $pip_list == '' ]]; then
+    echo 'PyInstaller not installed'
+    echo 'Please install it with "pip install pyinstaller"'
+    exit 1
+fi
+
+# Check if grip is installed
+pip_list=`pip list | grep 'grip'` || pip_list=''
+if [[ $pip_list == '' ]]; then
+    echo 'grip not installed'
+    echo 'Please install it with "pip install grip"'
+    exit 1
+fi
+
+
+# Download annie
+if [[ ! -f ./build/annie.tar.gz ]]; then
+    if [[ $ARCH == 'x86_64' ]]; then
+        version='64'
+    else
+        version='32'
+    fi
+
+    api='https://api.github.com/repos/iawia002/annie/releases/latest'
+    annie_url=`wget -qO- $api \
+        | grep "browser_download_url.*Linux_${version}.*" \
+        | cut -d '"' -f 4`
+    echo "Downloading annie from ${annie_url} to ./build/annie.tar.gz"
+    mkdir -p build
+    wget -O build/annie.tar.gz -q $annie_url
+    echo 'Extracting ./build/annie.tar.gz to ./build/annie'
+    tar xf ./build/annie.tar.gz -C build --overwrite
+else
+    echo 'annie already exists at ./build/annie.tar.gz'
+    echo 'If you want to re-download it, please remove it mannually'
+fi
+
+# Build README.html with grip
+echo 'Building README.html'
+grip README.md --export ./build/README.html --title 'QuickCut' --quiet
+echo 'Built ./build/README.html'
+
+# Build QuickCut with PyInstaller
+echo 'Building with PyInstaller'
+pyinstaller -wy \
+    -i icon.ico \
+    --log-level WARN \
+    --add-data "./build/README.html${SEP}." \
+    --add-data "icon.ico${SEP}." \
+    --add-data "sponsor.jpg${SEP}." \
+    --add-data "assets${SEP}assets" \
+    --add-data "languages${SEP}languages" \
+    --add-binary "./build/annie${SEP}." \
+    QuickCut.py
+echo 'Build complete'
+
+echo 'Archiving built files'
+archive_name="QuickCut_Linux_${VERSION}_pyinstaller.tar.gz"
+tar cfz ./dist/$archive_name -C dist QuickCut --overwrite
+echo "Archive created at ./dist/${archive_name}"
+


### PR DESCRIPTION
运行方法：

```
./build_linux_pyinstaller
```

这个脚本能完成这些工作：
1. 检测 setuptools 是否为最新版本
2. 检测是否安装 PyInstaller 和 grip
3. 下载最新版本的 annie
4. 使用 grip 把 README.md 渲染为 README.html
5. 使用 PyInstaller 编译 QuickCut.py ，并添加所需的各个文件及文件夹
6. 将所有的文件打包，并命名为 QuickCut_Linux_版本号_pyinstaller.tar.gz

脚本（可能）存在的问题：
1. ffmpeg 和 ffprobe 没有包括在压缩包里。对于 Linux 用户来说，可以很方便的使用系统自带的包管理器安装依赖，且这两个程序也并不是 QuickCut 唯一的依赖（如运行 Qt 的程序前也需要安装对应依赖），因此并没有必要把它们一起打包，让用户自己安装就可以了。但如果一定要把它们打包进来的话，可以考虑让脚本下载编译好的二进制文件（自己编译各种选项和依赖会比较麻烦），但我试了一下速度感人
2. 只检测了3个需要安装的包，其他 Python 包假定已经安装了，而需要系统的包管理器安装的包没有检测
3. grip 渲染出的 README.html 和 [Github 页面上](https://github.com/HaujetZhao/QuickCut)显示的一样，但和 Typora 渲染出的不一样，似乎 Github 的风格没有 Typora 的好看，但暂时没有找到更好的替代
4. 只在 Ubuntu 18.04 上测试过，不知道其他发行版能不能正常运行，可能需要更多人帮忙测试一下

本来其实想写成 Makefile 的，但无奈没学过只好写成 shell 脚本了😂，不过至少能用。另外 Nuitka 的编译过程太反人类了，感觉要写出脚本来会很困难。

后续可能会再写一个 Windows 用的脚本，不过因为不会 bat 所以可能写成 Python 脚本，但我没用过 Mac OS 所以没法给每个系统都写个脚本了，希望有人帮忙写一下，这样以后对于 PyInstaller 的版本就可以把脚本交给 Github Actions 自动编译发布了。