### PR TITLE
新增更新检查

### DIFF
--- a/QuickCut.py
+++ b/QuickCut.py
@@ -6158,6 +6158,7 @@ class _UpdateCheckerWorker(QObject):
         'https://api.github.com/repos/HaujetZhao/QuickCut/releases/latest'
     _gitee_api = \
         'https://gitee.com/api/v5/repos/haujet/QuickCut/releases/latest'
+    _gitee_release = 'https://gitee.com/haujet/QuickCut/releases'
     signal = pyqtSignal(tuple)
 
     def __init__(self, site, parent=None):
@@ -6195,7 +6196,7 @@ class _UpdateCheckerWorker(QObject):
             if self._site == 'github':
                 release_url = r_json['html_url']
             else:
-                release_url = r_json['assets'][0]['browser_download_url']
+                release_url = f'{self._gitee_release}/{latest_version}'
         else:
             update_info = None
             release_url = None

--- a/QuickCut.py
+++ b/QuickCut.py
@@ -162,6 +162,11 @@ class MainWindow(QMainWindow):
     def showEvent(self, event):
         self._update_checker = UpdateChecker()
         self._update_checker.check_for_update()
+        self._update_checker.update_dialog.setParent(self)
+        # Setting the dialog's parent resets its flags
+        # See https://forum.qt.io/topic/10477
+        self._update_checker.update_dialog.setWindowFlags(
+            Qt.WindowTitleHint | Qt.WindowCloseButtonHint | Qt.Dialog)
 
     def onUpdateText(self, text):
         """Write console output to text widget."""
@@ -4734,7 +4739,7 @@ class _UpdateDialogUI:
         UpdateDialog.setObjectName('UpdateDialog')
         UpdateDialog.resize(350, 500)
         UpdateDialog.setWindowFlags(
-            Qt.WindowTitleHint | Qt.WindowCloseButtonHint)
+            Qt.WindowTitleHint | Qt.WindowCloseButtonHint | Qt.Dialog)
         if platfm == 'Windows':
             UpdateDialog.setWindowIcon(QIcon('icon.ico'))
         else:
@@ -6142,6 +6147,10 @@ class UpdateChecker:
     def check_for_update(self):
         self._github_thread.start()
         self._gitee_thread.start()
+
+    @property
+    def update_dialog(self):
+        return self._update_dialog
 
 
 class _UpdateCheckerWorker(QObject):

--- a/QuickCut.py
+++ b/QuickCut.py
@@ -4844,7 +4844,7 @@ class UpdateDialog(QDialog, _UpdateDialogUI):
         if self.update_info_text.toMarkdown() == '' and info is not None:
             self.update_info_text.setMarkdown(info)
 
-        # Show dialog when it have both results of Github and Gitee, and
+        # Show dialog when it has both results of Github and Gitee, and
         # update is available
         if self.github_set and self.gitee_set and self.update_avail:
             self.show()

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ tencentcloud-sdk-python
 oss2
 pyaudio
 auditok @ git+https://github.com/amsehili/auditok@v0.1.8
+requests
 ```
 
 其中，pyaudio 很难安装！编译成功有很多要求。所以 Windows 用户可以直接到 [这里](https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyaudio) 下载已经被志愿者编译好的 whl 包，用 pip 安装，注意下载对应你 python 版本的包。

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ tencentcloud-sdk-python
 oss2
 pyaudio
 auditok @ git+https://github.com/amsehili/auditok@v0.1.8
+requests


### PR DESCRIPTION
## 一些细节

* 新引入了一个 Python 包 `requests`，用标准库发请求太麻烦了。
* 会同时向 Github 和 Gitee 的 API 发送请求，两个都收到正常 response 后、且有更新时，才会显示更新提醒。如果其中一个在尝试5次后依旧无法正常获得 response 则放弃请求并禁用相应按钮。
* 访问 Github 的 API 有一定概率会遭遇某著名 TCP 重置攻击，因此会经常看到 Github 的按钮是灰的。
* 手画 UI 太累了，是用`pyuic5`转换`.ui`文件后稍作修改绘制出的 UI，因此代码风格会和其他窗口不一样。
* 假定 Github 和 Gitee 上的 latest release 永远是最新的，即用户永远不会拿到比这还要新的版本，因此直接使用了`!=`来比较版本。
* 假定 Github 和 Gitee 上的更新信息（即要在`UpdateDialog.update_info_text`里显示的那些信息）一模一样，因此只选用了其中较早获得的一个来显示。
* 点击按钮后会直接进入对应版本的 release 页面。经测试 Github 的链接正确，但因为没有 Gitee 的账号，提示“登录后才可以下载, 请先登录”，所以就没有测试 Gitee 的链接，希望帮忙测试一下。

## 一些题外话

* Github 和 Gitee 的 API 竟然惊人得相似，本来想分两个方法写的，没想到可以直接写成一个
* 以前学编程的时候只是听说分模块会方便维护就照做了，没真正理解为什么会方便维护；现在真正体验了一下维护不分模块的代码有多累，才真正理解这个道理🤣